### PR TITLE
Add accuracy tracking and language field (#61)

### DIFF
--- a/R/refinement.R
+++ b/R/refinement.R
@@ -39,11 +39,11 @@ refine_records <- function(db_conn = NULL, document_id,
     }
 
     # Filter out protected records that should not be refined
-    # - human_edited: User manually edited (timestamp), don't touch
+    # - human_edited: User manually edited (derived from record_edits table), don't touch
     # - deleted_by_user: User flagged for deletion (timestamp), don't re-extract or refine
     if (nrow(existing_records) > 0) {
-      # Check for non-NULL timestamps (NULL/NA means not edited/deleted)
-      is_human_edited <- !is.na(existing_records$human_edited)
+      # human_edited is a derived boolean column (TRUE/FALSE)
+      is_human_edited <- existing_records$human_edited
       is_deleted <- if ("deleted_by_user" %in% names(existing_records)) {
         !is.na(existing_records$deleted_by_user)
       } else {

--- a/inst/extdata/metadata_schema.json
+++ b/inst/extdata/metadata_schema.json
@@ -63,6 +63,10 @@
             "type": "string",
             "description": "Individual reference citation as it appears in the document"
           }
+        },
+        "language": {
+          "type": ["string", "null"],
+          "description": "Primary language of the document as ISO 639-1 two-letter code (e.g., 'en' for English, 'es' for Spanish, 'fr' for French, 'de' for German, 'pt' for Portuguese, 'zh' for Chinese, 'ja' for Japanese)"
         }
       }
     }


### PR DESCRIPTION
- Add record_edits audit table to track column-level human edits
- Remove human_edited column from records table (now derived from record_edits)
- Add added_by_user column to track human-added records
- Add calculate_accuracy() function for precision/recall/F1 metrics
- Add language field to documents table and metadata schema (ISO 639-1)
- Update save_document() to track edits in audit table
- Update get_records() and get_existing_records() to derive human_edited